### PR TITLE
fix `vagrant up` failing due to virtualbox cable disconnected

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant.configure(2) do |config|
     config.vm.box = "bento/ubuntu-16.04"
     config.vm.provider "virtualbox" do |v|
         v.memory = 2048
+        v.customize ['modifyvm', :id, '--cableconnected1', 'on']
     end
     config.vm.provider "vmware_workstation" do |v|
         v.vmx['memsize'] = '2048'


### PR DESCRIPTION
Solves #3 by adding to `Vagrantfile`: vbox NAT network interface is explicitly configured to be connected.